### PR TITLE
build(makefile): add a formatting rule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,4 +21,5 @@ BraceWrapping:
 AlignAfterOpenBracket: true
 AlwaysBreakTemplateDeclarations: true
 AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
 SortIncludes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,6 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-      - run: TOOLS_PATH=/home/ubuntu/dev/tools make
+      - run: make format && git diff --quiet
       - run: make cppcheck
+      - run: TOOLS_PATH=/home/ubuntu/dev/tools make

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ CC = $(MSPGCC_BIN_DIR)/msp430-elf-gcc
 RM = rm
 DEBUG = LD_LIBRARY_PATH=$(DEBUG_DRIVERS_DIR) $(DEBUG_BIN_DIR)/mspdebug
 CPPCHECK = cppcheck
+FORMAT = clang-format-12
 
 # Files
 TARGET = $(BIN_DIR)/nsumo
@@ -63,7 +64,7 @@ $(OBJ_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $^
 
 # Phonies
-.PHONY: all clean flash cppcheck
+.PHONY: all clean flash cppcheck format
 
 all: $(TARGET)
 
@@ -80,3 +81,5 @@ cppcheck:
 	$(SOURCES) \
 	-i external/printf
 
+format:
+	@$(FORMAT) -i $(SOURCES)

--- a/tools/dockerfile
+++ b/tools/dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Install necessary packages
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update \
-    && apt-get install -y wget bzip2 make unzip cppcheck clang-format-12
+    && apt-get install -y wget bzip2 make unzip cppcheck clang-format-12 git
 
 # Create a non-root user named "ubuntu"
 # But put in root group since GitHub actions needs permissions


### PR DESCRIPTION
All the code in this project should be formatted with the auto-formatter clang-format. Add a Makefile rule to make it easy to format all files in one go from the commandline. There was already a .clang-format config file added previously.

video: 11