### PR TITLE
build: add two makefile rules for analyzing flash space used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ RM = rm
 DEBUG = LD_LIBRARY_PATH=$(DEBUG_DRIVERS_DIR) $(DEBUG_BIN_DIR)/mspdebug
 CPPCHECK = cppcheck
 FORMAT = clang-format-12
+SIZE = $(MSPGCC_BIN_DIR)/msp430-elf-size
+READELF = $(MSPGCC_BIN_DIR)/msp430-elf-readelf
 
 # Files
 TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
@@ -128,3 +130,10 @@ cppcheck:
 
 format:
 	@$(FORMAT) -i $(SOURCES) $(HEADERS)
+
+size: $(TARGET)
+	@$(SIZE) $(TARGET)
+
+symbols: $(TARGET)
+	# List symbols table sorted by size
+	@$(READELF) -s $(TARGET) | sort -n -k3

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -24,7 +24,7 @@ static_assert(sizeof(io_generic_e) == 1, "Unexpected size, -fshort-enums missing
 #define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)
 #define IO_PIN_MASK (0x7u)
 
-static inline uint8_t io_port(io_e io)
+static uint8_t io_port(io_e io)
 {
     return (io & IO_PORT_MASK) >> IO_PORT_OFFSET;
 }
@@ -34,7 +34,7 @@ static inline uint8_t io_pin_idx(io_e io)
     return io & IO_PIN_MASK;
 }
 
-static inline uint8_t io_pin_bit(io_e io)
+static uint8_t io_pin_bit(io_e io)
 {
     return 1 << io_pin_idx(io);
 }


### PR DESCRIPTION
msp430g2553 only has 16kB of FLASH, so care must be taken when programming it as to not run out of this small space. The GCC-toolchain has several tools for seeing how much space the code occupies, add these as rules to the Makefile.

While at it, remove "inline" from some of the IO functions because they apparently occupy more space as inlined. May lead to more CPU cycles, but insignificant, and prefer space over speed in this case.

video: 16