### PR TITLE
feat(drivers): UART driver and ring buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,11 @@ TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
 
 SOURCES_WITH_HEADERS = \
 		src/common/assert_handler.c \
+		src/common/ring_buffer.c \
 		src/drivers/mcu_init.c \
 		src/drivers/io.c \
 		src/drivers/led.c \
+		src/drivers/uart.c \
 		src/app/drive.c \
 		src/app/enemy.c \
 

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -9,6 +9,15 @@
         }                                                                                          \
     } while (0)
 
+// TODO: Decide what this should do
+#define ASSERT_INTERRUPT(expression)                                                               \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            while (1)                                                                              \
+                ;                                                                                  \
+        }                                                                                          \
+    } while (0)
+
 void assert_handler(void);
 
 #endif // ASSERT_HANDLER_H

--- a/src/common/ring_buffer.c
+++ b/src/common/ring_buffer.c
@@ -1,0 +1,43 @@
+#include "common/ring_buffer.h"
+
+void ring_buffer_put(struct ring_buffer *rb, uint8_t data)
+{
+    rb->buffer[rb->head] = data;
+    rb->head++;
+
+    // Avoid expensive modulo operation
+    if (rb->head == rb->size) {
+        rb->head = 0;
+    }
+}
+
+uint8_t ring_buffer_get(struct ring_buffer *rb)
+{
+    const uint8_t data = rb->buffer[rb->tail];
+    rb->tail++;
+
+    // Avoid expensive modulo operation
+    if (rb->tail == rb->size) {
+        rb->tail = 0;
+    }
+    return data;
+}
+
+uint8_t ring_buffer_peek(const struct ring_buffer *rb)
+{
+    return rb->buffer[rb->tail];
+}
+
+bool ring_buffer_empty(const struct ring_buffer *rb)
+{
+    return rb->head == rb->tail;
+}
+
+bool ring_buffer_full(const struct ring_buffer *rb)
+{
+    uint8_t idx_after_head = rb->head + 1;
+    if (idx_after_head == rb->size) {
+        idx_after_head = 0;
+    }
+    return idx_after_head == rb->tail;
+}

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -1,0 +1,24 @@
+#ifndef RING_BUFFER_H
+#define RING_BUFFER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+struct ring_buffer
+{
+    uint8_t *buffer;
+    uint8_t size;
+    uint8_t head;
+    uint8_t tail;
+};
+
+// Caller must check if full
+void ring_buffer_put(struct ring_buffer *rb, uint8_t data);
+// Caller must check if empty
+uint8_t ring_buffer_get(struct ring_buffer *rb);
+// Caller must check if empty
+uint8_t ring_buffer_peek(const struct ring_buffer *rb);
+bool ring_buffer_empty(const struct ring_buffer *rb);
+bool ring_buffer_full(const struct ring_buffer *rb);
+
+#endif // RING_BUFFER_H

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -13,10 +13,10 @@ static void init_clocks()
 
     /* Configure the internal oscillator (main clock) to run at 16 MHz.
      * This clock is used as a reference to produce a more stable DCO. */
-    BCSCTL1 |= CALBC1_16MHZ;
+    BCSCTL1 = CALBC1_16MHZ;
 
     // Sets the clock rate of the digitally controlled oscillator (DCO)
-    DCOCTL |= CALDCO_16MHZ;
+    DCOCTL = CALDCO_16MHZ;
 
     /* Set DCO as source for
      * MCLK: Master clock drives the CPU and some peripherals

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -1,0 +1,136 @@
+#include "drivers/uart.h"
+#include "common/ring_buffer.h"
+#include "common/assert_handler.h"
+#include <msp430.h>
+#include <assert.h>
+#include <stdint.h>
+
+#define UART_BUFFER_SIZE (16)
+static uint8_t buffer[UART_BUFFER_SIZE];
+static struct ring_buffer tx_buffer = { .buffer = buffer, .size = sizeof(buffer) };
+
+/* Calculate the integer and fractional part of the divisor
+ * N = (Clock source / Desired baudrate)
+ * for Low-Frequency Baud Rate Mode.
+ *
+ * These are used to configure the desired baudrate.
+ *
+ * For information on the corresponding transmission error
+ * for common values, please refer to the table provided in
+ * the family user guide (SLAU144K). */
+#define SMCLK (16000000u)
+#define BRCLK (SMCLK)
+#define UART_BAUD_RATE (115200u)
+static_assert(UART_BAUD_RATE < (BRCLK / 3.0f),
+              "Baudrate must be smaller than 1/3 of input clock in Low-Frequency Mode");
+#define UART_DIVISOR ((float)BRCLK / UART_BAUD_RATE)
+static_assert(UART_DIVISOR < 0xFFFFu, "Sanity check divisor fits in 16-bit");
+#define UART_DIVISOR_INT_16BIT ((uint16_t)UART_DIVISOR)
+#define UART_DIVISOR_INT_LOW_BYTE (UART_DIVISOR_INT_16BIT & 0xFF)
+#define UART_DIVISOR_INT_HIGH_BYTE (UART_DIVISOR_INT_16BIT >> 8)
+#define UART_DIVISOR_FRACTIONAL (UART_DIVISOR - UART_DIVISOR_INT_16BIT)
+#define UART_UCBRS ((uint8_t)(8 * UART_DIVISOR_FRACTIONAL))
+#define UART_UCBRF (0)
+#define UART_UC0S16 (0)
+static_assert(UART_UCBRS < 8, "Sanity check second modulation stage value fits in 3-bit");
+
+static inline void uart_tx_clear_interrupt(void)
+{
+    IFG2 &= ~UCA0TXIFG;
+}
+
+static inline void uart_tx_enable_interrupt(void)
+{
+    UC0IE |= UCA0TXIE;
+}
+
+static inline void uart_tx_disable_interrupt(void)
+{
+    UC0IE &= ~UCA0TXIE;
+}
+
+static void uart_tx_start(void)
+{
+    if (!ring_buffer_empty(&tx_buffer)) {
+        UCA0TXBUF = ring_buffer_peek(&tx_buffer);
+    }
+}
+
+__attribute__((interrupt(USCIAB0TX_VECTOR))) void isr_uart_tx()
+{
+    ASSERT_INTERRUPT(!ring_buffer_empty(&tx_buffer));
+
+    // Remove the transmitted data byte from the buffer
+    ring_buffer_get(&tx_buffer);
+
+    // Clear interrupt here to avoid accidently clearing interrupt for next transmission
+    uart_tx_clear_interrupt();
+
+    if (!ring_buffer_empty(&tx_buffer)) {
+        uart_tx_start();
+    }
+}
+
+static bool initialized = false;
+void uart_init(void)
+{
+    ASSERT(!initialized);
+
+    /* Reset module. It stays in reset until cleared. The module should be in reset
+     * condition while configured according to the user guide (SLAU144K). */
+    UCA0CTL1 &= UCSWRST;
+
+    /* Use default (data word length 8 bits, 1 stop bit, no parity bit)
+     * [ Start (1 bit) | Data (8 bits) | Stop (1 bit) ] */
+    UCA0CTL0 = 0;
+
+    // Set SMCLK as clock source.
+    UCA0CTL1 |= UCSSEL_2;
+
+    // Set clock prescaler to the integer part of divisor N.
+    UCA0BR0 = UART_DIVISOR_INT_LOW_BYTE;
+    UCA0BR1 = UART_DIVISOR_INT_HIGH_BYTE;
+
+    /* Set modulation to account for the fractional part of divisor N.
+     * UCA0MCTL = [UCBRF (4 bits) | UCBRS (3 bits) | UC0S16 (1 bit) ] */
+    UCA0MCTL = (UART_UCBRF << 4) + (UART_UCBRS << 1) + UART_UC0S16;
+
+    // Clear reset to release the module for operation.
+    UCA0CTL1 &= ~UCSWRST;
+
+    // Interrupt triggers when TX buffer is empty, which it is after boot, so clear it here.
+    uart_tx_clear_interrupt();
+
+    uart_tx_enable_interrupt();
+
+    initialized = true;
+}
+
+void uart_putchar_interrupt(char c)
+{
+    // Poll if full
+    while (ring_buffer_full(&tx_buffer))
+        ;
+
+    uart_tx_disable_interrupt();
+    const bool tx_ongoing = !ring_buffer_empty(&tx_buffer);
+    ring_buffer_put(&tx_buffer, c);
+    if (!tx_ongoing) {
+        uart_tx_start();
+    }
+    uart_tx_enable_interrupt();
+
+    // Some terminals expect carriage return (\r) after line-feed (\n) for proper new line.
+    if (c == '\n') {
+        uart_putchar_interrupt('\r');
+    }
+}
+
+void uart_print_interrupt(const char *string)
+{
+    int i = 0;
+    while (string[i] != '\0') {
+        uart_putchar_interrupt(string[i]);
+        i++;
+    }
+}

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -1,0 +1,9 @@
+#ifndef UART_H
+#define UART_H
+
+void uart_init(void);
+// TODO: Replace with printf
+void uart_putchar_interrupt(char c);
+void uart_print_interrupt(const char *string);
+
+#endif // UART_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -1,6 +1,7 @@
 #include "drivers/io.h"
 #include "drivers/mcu_init.h"
 #include "drivers/led.h"
+#include "drivers/uart.h"
 #include "common/assert_handler.h"
 #include "common/defines.h"
 #include <msp430.h>
@@ -134,6 +135,17 @@ static void test_io_interrupt(void)
     io_enable_interrupt(IO_11);
     io_enable_interrupt(IO_20);
     while(1);
+}
+
+SUPPRESS_UNUSED
+static void test_uart(void)
+{
+    test_setup();
+    uart_init();
+    while (1) {
+        uart_print_interrupt("Artful Bytes\n");
+        BUSY_WAIT_ms(100);
+    }
 }
 
 int main()


### PR DESCRIPTION
Add a driver for the UART peripheral that can transmit individual characters. Make it interrupt driven and put the characters in a ring buffer that the interrupt can feed from. This is going to be used to implement tracing (printf) in the future.

Also, write the calibrated clock values correctly.

This was tested by connecting the LAUNCHPAD to a PC via a USB-to-UART bridge and using the command:
picocom -b 115200 /dev/ttyUSB0

video: 18