### PR TITLE
feat(trace): use external printf implementation for trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          submodules: "true"
       - run: make format && git diff --quiet
       - run: make cppcheck
       - run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=NSUMO

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LIB_DIRS = $(MSPGCC_INCLUDE_DIR)
 INCLUDE_DIRS = $(MSPGCC_INCLUDE_DIR) \
 			   ./src \
 			   ./external/ \
-			   ./external/printf
+			   ./
 
 # Toolchain
 CC = $(MSPGCC_BIN_DIR)/msp430-elf-gcc
@@ -52,12 +52,14 @@ TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
 SOURCES_WITH_HEADERS = \
 		src/common/assert_handler.c \
 		src/common/ring_buffer.c \
+		src/common/trace.c \
 		src/drivers/mcu_init.c \
 		src/drivers/io.c \
 		src/drivers/led.c \
 		src/drivers/uart.c \
 		src/app/drive.c \
 		src/app/enemy.c \
+		external/printf/printf.c \
 
 ifndef TEST
 SOURCES = \
@@ -83,12 +85,17 @@ HW_DEFINE = $(addprefix -D,$(HW))
 TEST_DEFINE = $(addprefix -DTEST=,$(TEST))
 DEFINES = \
 	$(HW_DEFINE) \
-	$(TEST_DEFINE)
+	$(TEST_DEFINE) \
+	-DPRINTF_INCLUDE_CONFIG_H \
 
 # Static Analysis
 ## Don't check the msp430 helper headers (they have a LOT of ifdefs)
-CPPCHECK_INCLUDES = ./src
-CPPCHECK_IGNORE = external/printf
+CPPCHECK_INCLUDES = ./src ./
+IGNORE_FILES_FORMAT_CPPCHECK = \
+	external/printf/printf.h \
+	external/printf/printf.c
+SOURCES_FORMAT_CPPCHECK = $(filter-out $(IGNORE_FILES_FORMAT_CPPCHECK),$(SOURCES))
+HEADERS_FORMAT = $(filter-out $(IGNORE_FILES_FORMAT_CPPCHECK),$(HEADERS))
 CPPCHECK_FLAGS = \
 	--quiet --enable=all --error-exitcode=1 \
 	--inline-suppr \
@@ -96,7 +103,6 @@ CPPCHECK_FLAGS = \
 	--suppress=unmatchedSuppression \
 	--suppress=unusedFunction \
 	$(addprefix -I,$(CPPCHECK_INCLUDES)) \
-	$(addprefix -i,$(CPPCHECK_IGNORE))
 
 # Flags
 MCU = msp430g2553
@@ -128,10 +134,10 @@ flash: $(TARGET)
 	@$(DEBUG) tilib "prog $(TARGET)"
 
 cppcheck:
-	@$(CPPCHECK) $(CPPCHECK_FLAGS) $(SOURCES)
+	@$(CPPCHECK) $(CPPCHECK_FLAGS) $(SOURCES_FORMAT_CPPCHECK)
 
 format:
-	@$(FORMAT) -i $(SOURCES) $(HEADERS)
+	@$(FORMAT) -i $(SOURCES_FORMAT_CPPCHECK) $(HEADERS_FORMAT)
 
 size: $(TARGET)
 	@$(SIZE) $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ CPPCHECK = cppcheck
 FORMAT = clang-format-12
 SIZE = $(MSPGCC_BIN_DIR)/msp430-elf-size
 READELF = $(MSPGCC_BIN_DIR)/msp430-elf-readelf
+ADDR2LINE = $(MSPGCC_BIN_DIR)/msp430-elf-addr2line
 
 # Files
 TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
@@ -145,3 +146,6 @@ size: $(TARGET)
 symbols: $(TARGET)
 	# List symbols table sorted by size
 	@$(READELF) -s $(TARGET) | sort -n -k3
+
+addr2line: $(TARGET)
+	@$(ADDR2LINE) -e $(TARGET) $(ADDR)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ make symbols
 ```
 which is useful to track down the worst offenders.
 
+## Assert
+Several things happen when an assert occurs to make it easy to detect and localize.
+First it triggers a breakpoint (if a debugger is attached), then it traces the address
+of the assert, and finally it endlessly blinks an LED. The address printed, is the
+program counter, and _addr2line can be used to retrieve the file and line number,
+and there is a makefile rule for it. For example, if an assert triggered at address
+0x1234, you can run
+
+```
+make HW=LAUNCHPAD addr2line ADDR=0x1234
+```
+
 ## Schematic
 <img src="/docs/schematic.png">
 

--- a/external/printf_config.h
+++ b/external/printf_config.h
@@ -1,0 +1,13 @@
+#ifndef PRINTF_CONFIG_H
+#define PRINTF_CONFIG_H
+
+/* Configuration file for the mpaland printf implementation (see external/printf).
+ * PRINTF_INCLUDE_CONFIG_H must be defined as a compiler switch for this to be picked up */
+
+// Disable everything not used to reduce flash usage
+#define PRINTF_DISABLE_SUPPORT_LONG_LONG
+#define PRINTF_DISABLE_SUPPORT_PTRDIFF_T
+#define PRINTF_DISABLE_SUPPORT_EXPONENTIAL
+#define PRINTF_DISABLE_SUPPORT_FLOAT
+
+#endif // PRINTF_CONFIG_H

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -1,5 +1,7 @@
 #include "common/assert_handler.h"
 #include "common/defines.h"
+#include "drivers/uart.h"
+#include "external/printf/printf.h"
 #include <msp430.h>
 
 /* The TI compiler provides intrinsic support for calling a specific opcode, which means
@@ -8,16 +10,22 @@
  * to assembly instruction "CLR.B R3". */
 #define BREAKPOINT __asm volatile("CLR.B R3");
 
-/* Minimize code dependency in this function to reduce the risk of accidently calling
- * a function with an assert in it, which would cause the assert_handler to be called
- * recursively until stack overflow. */
-void assert_handler(void)
+// Text + Program counter + Null termination
+#define ASSERT_STRING_MAX_SIZE (15u + 6u + 1u)
+
+static void assert_trace(uint16_t program_counter)
 {
-    // TODO: Turn off motors ("safe state")
-    // TODO: Trace to console
+    // UART Tx
+    P1SEL |= BIT1;
+    P1SEL2 |= BIT1;
+    uart_init_assert();
+    char assert_string[ASSERT_STRING_MAX_SIZE];
+    snprintf(assert_string, sizeof(assert_string), "ASSERT 0x%x\n", program_counter);
+    uart_trace_assert(assert_string);
+}
 
-    BREAKPOINT
-
+static void assert_blink_led(void)
+{
     // Configure TEST LED pin on LAUNCHPAD
     P1SEL &= ~(BIT0);
     P1SEL2 &= ~(BIT0);
@@ -36,4 +44,15 @@ void assert_handler(void)
         P2OUT ^= BIT6;
         BUSY_WAIT_ms(250);
     };
+}
+
+/* Minimize code dependency in this function to reduce the risk of accidently calling
+ * a function with an assert in it, which would cause the assert_handler to be called
+ * recursively until stack overflow. */
+void assert_handler(uint16_t program_counter)
+{
+    // TODO: Turn off motors ("safe state")
+    BREAKPOINT
+    assert_trace(program_counter);
+    assert_blink_led();
 }

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,11 +1,15 @@
 #ifndef ASSERT_HANDLER_H
 
+#include <stdint.h>
+
 // Assert implementation suitable for a microcontroller
 
 #define ASSERT(expression)                                                                         \
     do {                                                                                           \
         if (!(expression)) {                                                                       \
-            assert_handler();                                                                      \
+            uint16_t pc;                                                                           \
+            asm volatile("mov pc, %0" : "=r"(pc));                                                 \
+            assert_handler(pc);                                                                    \
         }                                                                                          \
     } while (0)
 
@@ -13,11 +17,10 @@
 #define ASSERT_INTERRUPT(expression)                                                               \
     do {                                                                                           \
         if (!(expression)) {                                                                       \
-            while (1)                                                                              \
-                ;                                                                                  \
+            while (1) { }                                                                          \
         }                                                                                          \
     } while (0)
 
-void assert_handler(void);
+void assert_handler(uint16_t program_counter);
 
 #endif // ASSERT_HANDLER_H

--- a/src/common/trace.c
+++ b/src/common/trace.c
@@ -1,0 +1,25 @@
+#ifndef DISABLE_TRACE
+#include "common/trace.h"
+#include "common/assert_handler.h"
+#include "drivers/uart.h"
+#include "external/printf/printf.h"
+#include <stdbool.h>
+
+static bool initialized = false;
+void trace_init(void)
+{
+    ASSERT(!initialized);
+    uart_init();
+    initialized = true;
+}
+
+void trace(const char *format, ...)
+{
+    ASSERT(initialized);
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+}
+
+#endif // DISABLE_TRACE

--- a/src/common/trace.h
+++ b/src/common/trace.h
@@ -1,0 +1,14 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+#define TRACE(fmt, ...) trace("%s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#ifndef DISABLE_TRACE
+void trace_init(void);
+void trace(const char *format, ...);
+#else
+#define trace_init() ;
+#define trace(fmt, ...) ;
+#endif
+
+#endif // TRACE_H

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -72,11 +72,8 @@ INTERRUPT_FUNCTION(USCIAB0TX_VECTOR) isr_uart_tx()
     }
 }
 
-static bool initialized = false;
-void uart_init(void)
+static void uart_configure(void)
 {
-    ASSERT(!initialized);
-
     /* Reset module. It stays in reset until cleared. The module should be in reset
      * condition while configured according to the user guide (SLAU144K). */
     UCA0CTL1 &= UCSWRST;
@@ -98,12 +95,16 @@ void uart_init(void)
 
     // Clear reset to release the module for operation.
     UCA0CTL1 &= ~UCSWRST;
+}
 
+static bool initialized = false;
+void uart_init(void)
+{
+    ASSERT(!initialized);
+    uart_configure();
     // Interrupt triggers when TX buffer is empty, which it is after boot, so clear it here.
     uart_tx_clear_interrupt();
-
     uart_tx_enable_interrupt();
-
     initialized = true;
 }
 
@@ -124,5 +125,30 @@ void _putchar(char c)
     // Some terminals expect carriage return (\r) after line-feed (\n) for proper new line.
     if (c == '\n') {
         _putchar('\r');
+    }
+}
+
+void uart_init_assert(void)
+{
+    uart_tx_disable_interrupt();
+    uart_configure();
+}
+
+static void uart_putchar_polling(char c)
+{
+    while (!(IFG2 & UCA0TXIFG)) { }
+    UCA0TXBUF = c;
+    if (c == '\n') {
+        while (!(IFG2 & UCA0TXIFG)) { }
+        uart_putchar_polling('\r');
+    }
+}
+
+void uart_trace_assert(const char *string)
+{
+    int i = 0;
+    while (string[i] != '\0') {
+        uart_putchar_polling(string[i]);
+        i++;
     }
 }

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -4,4 +4,8 @@
 void uart_init(void);
 void _putchar(char c);
 
+// These functions should ONLY be called by assert_handler!
+void uart_init_assert(void);
+void uart_trace_assert(const char *string);
+
 #endif // UART_H

--- a/src/drivers/uart.h
+++ b/src/drivers/uart.h
@@ -2,8 +2,6 @@
 #define UART_H
 
 void uart_init(void);
-// TODO: Replace with printf
-void uart_putchar_interrupt(char c);
-void uart_print_interrupt(const char *string);
+void _putchar(char c);
 
 #endif // UART_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -5,6 +5,7 @@
 #include "common/assert_handler.h"
 #include "common/defines.h"
 #include <msp430.h>
+#include "common/trace.h"
 
 SUPPRESS_UNUSED
 static void test_setup(void)
@@ -143,7 +144,24 @@ static void test_uart(void)
     test_setup();
     uart_init();
     while (1) {
-        uart_print_interrupt("Artful Bytes\n");
+        _putchar('A');
+        _putchar('R');
+        _putchar('T');
+        _putchar('F');
+        _putchar('U');
+        _putchar('L');
+        _putchar('\n');
+        BUSY_WAIT_ms(100);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_trace(void)
+{
+    test_setup();
+    trace_init();
+    while (1) {
+        TRACE("Artful bytes %d", 2023);
         BUSY_WAIT_ms(100);
     }
 }


### PR DESCRIPTION
The standard library printf implementation is not appropriate for a microcontroller. A microcontroller has no notion of stdout and the standard printf implementation has a big memory footprint. To get around this, use a more stripped-down external implementation, mpaland/printf, and include it as a git submodule (already included). Use this to implement a trace function that can formatted strings.

video: 19