### PR TITLE
feat(drivers): ADC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ SOURCES_WITH_HEADERS = \
 		src/drivers/pwm.c \
 		src/drivers/tb6612fng.c \
 		src/drivers/adc.c \
+		src/drivers/qre1113.c \
 		src/app/drive.c \
 		src/app/enemy.c \
 		external/printf/printf.c \

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ SOURCES_WITH_HEADERS = \
 		src/drivers/ir_remote.c \
 		src/drivers/pwm.c \
 		src/drivers/tb6612fng.c \
+		src/drivers/adc.c \
 		src/app/drive.c \
 		src/app/enemy.c \
 		external/printf/printf.c \

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ SOURCES_WITH_HEADERS = \
 		src/drivers/qre1113.c \
 		src/app/drive.c \
 		src/app/enemy.c \
+		src/app/line.c \
 		external/printf/printf.c \
 
 ifndef TEST

--- a/src/app/line.c
+++ b/src/app/line.c
@@ -1,0 +1,54 @@
+#include "app/line.h"
+#include "drivers/qre1113.h"
+#include "common/assert_handler.h"
+#include <stdbool.h>
+
+// Based on readings from the sensors when they are above the white line
+#define LINE_DETECTED_VOLTAGE_THRESHOLD (700u)
+
+static bool initialized = false;
+void line_init(void)
+{
+    ASSERT(!initialized);
+    qre1113_init();
+    initialized = true;
+}
+
+line_e line_get(void)
+{
+    struct qre1113_voltages voltages;
+    qre1113_get_voltages(&voltages);
+    const bool front_left = voltages.front_left < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool front_right = voltages.front_right < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool back_left = voltages.back_left < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool back_right = voltages.back_right < LINE_DETECTED_VOLTAGE_THRESHOLD;
+
+    if (front_left) {
+        if (front_right) {
+            return LINE_FRONT;
+        } else if (back_left) {
+            return LINE_LEFT;
+        } else if (back_right) {
+            return LINE_DIAGONAL_LEFT;
+        } else {
+            return LINE_FRONT_LEFT;
+        }
+    } else if (front_right) {
+        if (back_right) {
+            return LINE_RIGHT;
+        } else if (back_left) {
+            return LINE_DIAGONAL_RIGHT;
+        } else {
+            return LINE_FRONT_RIGHT;
+        }
+    } else if (back_left) {
+        if (back_right) {
+            return LINE_BACK;
+        } else {
+            return LINE_BACK_LEFT;
+        }
+    } else if (back_right) {
+        return LINE_BACK_RIGHT;
+    }
+    return LINE_NONE;
+}

--- a/src/app/line.h
+++ b/src/app/line.h
@@ -1,0 +1,24 @@
+#ifndef LINE_H
+#define LINE_H
+
+// Detect the boundary line of the circular sumobot platform
+
+typedef enum
+{
+    LINE_NONE,
+    LINE_FRONT,
+    LINE_BACK,
+    LINE_LEFT,
+    LINE_RIGHT,
+    LINE_FRONT_LEFT,
+    LINE_FRONT_RIGHT,
+    LINE_BACK_LEFT,
+    LINE_BACK_RIGHT,
+    LINE_DIAGONAL_LEFT,
+    LINE_DIAGONAL_RIGHT
+} line_e;
+
+void line_init(void);
+line_e line_get(void);
+
+#endif // LINE_H

--- a/src/drivers/adc.c
+++ b/src/drivers/adc.c
@@ -1,0 +1,93 @@
+#include "drivers/adc.h"
+#include "drivers/io.h"
+#include "common/defines.h"
+#include "common/assert_handler.h"
+#include <msp430.h>
+#include <stdbool.h>
+
+/* Strategy:
+ * Setup ADC to sample a sequence of channels including the channels
+ * of interest. Interrupt after the sequence has been sampled and cache
+ * the sampled values and start a new round. Let the caller retrieve
+ * the latest values from the cache. Use DMA (DTC) and slow clock (ACLK)
+ * to reduce CPU involvement. */
+static volatile adc_channel_values_t adc_dtc_block;
+static volatile adc_channel_values_t adc_dtc_block_cache;
+static const io_e *adc_pins;
+static uint8_t adc_pin_cnt;
+static uint8_t dtc_channel_cnt;
+
+static inline void adc_enable_and_start_conversion(void)
+{
+    ADC10CTL0 |= ENC + ADC10SC;
+}
+
+static bool initialized = false;
+void adc_init(void)
+{
+    ASSERT(!initialized);
+    adc_pins = io_adc_pins(&adc_pin_cnt);
+
+    uint8_t adc10ae0 = 0;
+    uint8_t last_idx = 0;
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t pin_idx = io_to_adc_idx(adc_pins[i]);
+        const uint8_t pin_bit = 1 << pin_idx;
+        adc10ae0 += pin_bit;
+        if (pin_idx > last_idx) {
+            last_idx = pin_idx;
+        }
+    }
+    const uint16_t inch = last_idx << 12;
+
+    /* inch: Select channels (last channel when CONSEQ_1)
+     * ADC10DIV_7: Clock division (higher means slower)
+     * CONSEQ_1: Sequence of channels
+     * SHS_0: ADC10SC bit starts conversion
+     * ADC10SSEL_1: ACLK as clock source (Slow) */
+    ADC10CTL1 = inch + ADC10DIV_7 + CONSEQ_1 + SHS_0 + ADC10SSEL_1;
+
+    /* ADC10ON: Enable
+     * SREF_0: Voltage reference (VCC and VSS)
+     * ADC10SHT_3: 64 * ADC10CLK sample and hold time (better readings?)
+     * MSC: Multiple sample conversion
+     * ADC10IE: Enable interrupt */
+    ADC10CTL0 = ADC10ON + SREF_0 + ADC10SHT_3 + MSC + ADC10IE;
+
+    // Enable ADC pins
+    ADC10AE0 = adc10ae0;
+
+    /* Use data transfer controller (DTC) to transfer data DMA-style from
+     * the sampled channels and interrupt afterwards. Note, CONSEQ_1 iterates
+     * the channels contiguously from last idx to 0. */
+    dtc_channel_cnt = last_idx + 1;
+    ADC10DTC0 = ADC10CT;
+    ADC10DTC1 = dtc_channel_cnt;
+    ADC10SA = (uint16_t)adc_dtc_block;
+
+    adc_enable_and_start_conversion();
+
+    initialized = true;
+}
+
+INTERRUPT_FUNCTION(ADC10_VECTOR) isr_adc10(void)
+{
+    for (uint8_t i = 0; i < dtc_channel_cnt; i++) {
+        // DTC writes the channel samples in opposite order
+        adc_dtc_block_cache[i] = adc_dtc_block[dtc_channel_cnt - 1 - i];
+    }
+    adc_enable_and_start_conversion();
+}
+
+void adc_get_channel_values(adc_channel_values_t values)
+{
+    /* For reason unclear to me, it's not enough to disable local ADC interrupt
+     * here as then ADC stops working after a while, so as a workaround disable
+     * interrupts globally. */
+    _disable_interrupts();
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t channel_idx = io_to_adc_idx(adc_pins[i]);
+        values[channel_idx] = adc_dtc_block_cache[channel_idx];
+    }
+    _enable_interrupts();
+}

--- a/src/drivers/adc.h
+++ b/src/drivers/adc.h
@@ -1,0 +1,14 @@
+#ifndef ADC_H
+#define ADC_H
+
+// ADC driver sampling the values of the ADC assigned IO pins (see io.c)
+
+#include <stdint.h>
+
+#define ADC_CHANNEL_COUNT (8u)
+typedef uint16_t adc_channel_values_t[ADC_CHANNEL_COUNT];
+
+void adc_init(void);
+void adc_get_channel_values(adc_channel_values_t values);
+
+#endif // ADC_H

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -93,6 +93,12 @@ static isr_function isr_functions[IO_INTERRUPT_PORT_CNT][IO_PIN_CNT_PER_PORT] = 
         IO_SELECT_GPIO, IO_RESISTOR_ENABLED, IO_DIR_OUTPUT, IO_OUT_LOW                             \
     }
 
+// Overriden by ADC, so just default it to floating input here
+#define ADC_CONFIG                                                                                 \
+    {                                                                                              \
+        IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW                             \
+    }
+
 // This array holds the initial configuration for all IO pins.
 static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PORT] = {
     // Output
@@ -115,11 +121,11 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
     [IO_MOTORS_LEFT_CC_1] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
     [IO_MOTORS_LEFT_CC_2] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
 
+    [IO_LINE_DETECT_FRONT_LEFT] = ADC_CONFIG,
+
 #if defined(LAUNCHPAD)
     // Unused pins
-    [IO_UNUSED_1] = UNUSED_CONFIG,
     [IO_UNUSED_2] = UNUSED_CONFIG,
-    [IO_UNUSED_3] = UNUSED_CONFIG,
     [IO_UNUSED_5] = UNUSED_CONFIG,
     [IO_UNUSED_9] = UNUSED_CONFIG,
     [IO_UNUSED_10] = UNUSED_CONFIG,
@@ -154,14 +160,16 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
     [IO_XSHUT_LEFT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
     [IO_XSHUT_FRONT_RIGHT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
 
-    // Overriden by ADC, so just default it to floating input here
-    [IO_LINE_DETECT_FRONT_RIGHT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT,
-                                     IO_OUT_LOW },
-    [IO_LINE_DETECT_FRONT_LEFT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT,
-                                    IO_OUT_LOW },
-    [IO_LINE_DETECT_BACK_RIGHT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT,
-                                    IO_OUT_LOW },
-    [IO_LINE_DETECT_BACK_LEFT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW },
+    [IO_LINE_DETECT_FRONT_RIGHT] = ADC_CONFIG,
+    [IO_LINE_DETECT_BACK_RIGHT] = ADC_CONFIG,
+    [IO_LINE_DETECT_BACK_LEFT] = ADC_CONFIG,
+#endif
+};
+
+static const io_e io_adc_pins_arr[] = { IO_LINE_DETECT_FRONT_LEFT,
+#if defined(NSUMO)
+                                        IO_LINE_DETECT_BACK_LEFT, IO_LINE_DETECT_FRONT_RIGHT,
+                                        IO_LINE_DETECT_BACK_RIGHT
 #endif
 };
 
@@ -300,6 +308,19 @@ io_in_e io_get_input(io_e io)
 static void io_clear_interrupt(io_e io)
 {
     *port_interrupt_flag_regs[io_port(io)] &= ~io_pin_bit(io);
+}
+
+const io_e *io_adc_pins(uint8_t *cnt)
+{
+    *cnt = ARRAY_SIZE(io_adc_pins_arr);
+    return io_adc_pins_arr;
+}
+
+uint8_t io_to_adc_idx(io_e io)
+{
+    // Only pins on port 1 supports ADC
+    ASSERT(io_port(io) == IO_PORT1);
+    return io_pin_idx(io);
 }
 
 /* This function also disables the interrupt because selecting the edge

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -2,6 +2,7 @@
 #define IO_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /* IO pins handling including pinmapping, initialization, and configuration.
  * This wraps the more crude register defines provided in the headers from
@@ -23,7 +24,7 @@ typedef enum
     IO_TEST_LED = IO_10,
     IO_UART_RXD = IO_11,
     IO_UART_TXD = IO_12,
-    IO_UNUSED_1 = IO_13,
+    IO_LINE_DETECT_FRONT_LEFT = IO_13,
     IO_UNUSED_2 = IO_14,
     IO_UNUSED_3 = IO_15,
     IO_PWM_MOTORS_LEFT = IO_16,
@@ -119,6 +120,8 @@ void io_set_direction(io_e io, io_dir_e direction);
 void io_set_resistor(io_e io, io_resistor_e resistor);
 void io_set_out(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io);
+const io_e *io_adc_pins(uint8_t *cnt);
+uint8_t io_to_adc_idx(io_e io);
 
 typedef void (*isr_function)(void);
 void io_configure_interrupt(io_e io, io_trigger_e trigger, isr_function isr);

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -22,6 +22,9 @@ static void init_clocks()
      * MCLK: Master clock drives the CPU and some peripherals
      * SMCLK: Subsystem master clock drives some peripherals */
     // BCSCTL2 default
+
+    // Select the internal Very Low Frequency oscillator (VLO) as ACLK source
+    BCSCTL3 = LFXT1S_2;
 }
 
 /* Watchdog is enabled by default and will reset the microcontroller repeatedly if not

--- a/src/drivers/qre1113.c
+++ b/src/drivers/qre1113.c
@@ -1,0 +1,25 @@
+#include "drivers/qre1113.h"
+#include "drivers/adc.h"
+#include "drivers/io.h"
+#include "common/assert_handler.h"
+#include <stdbool.h>
+
+static bool initialized = false;
+void qre1113_init(void)
+{
+    ASSERT(!initialized);
+    adc_init();
+    initialized = true;
+}
+
+void qre1113_get_voltages(struct qre1113_voltages *voltages)
+{
+    adc_channel_values_t values;
+    adc_get_channel_values(values);
+    voltages->front_left = values[io_to_adc_idx(IO_LINE_DETECT_FRONT_LEFT)];
+#if defined(NSUMO)
+    voltages->front_right = values[io_to_adc_idx(IO_LINE_DETECT_FRONT_RIGHT)];
+    voltages->back_left = values[io_to_adc_idx(IO_LINE_DETECT_BACK_LEFT)];
+    voltages->back_right = values[io_to_adc_idx(IO_LINE_DETECT_BACK_RIGHT)];
+#endif
+}

--- a/src/drivers/qre1113.h
+++ b/src/drivers/qre1113.h
@@ -1,0 +1,19 @@
+#ifndef QRE1113_H
+#define QRE1113_H
+
+// Driver for retrieving the voltage output from the line sensors QRE1113
+
+#include <stdint.h>
+
+struct qre1113_voltages
+{
+    uint16_t front_left;
+    uint16_t front_right;
+    uint16_t back_left;
+    uint16_t back_right;
+};
+
+void qre1113_init(void);
+void qre1113_get_voltages(struct qre1113_voltages *voltages);
+
+#endif // QRE1113_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -6,6 +6,7 @@
 #include "drivers/pwm.h"
 #include "drivers/tb6612fng.h"
 #include "drivers/adc.h"
+#include "drivers/qre1113.h"
 #include "app/drive.h"
 #include "common/assert_handler.h"
 #include "common/defines.h"
@@ -196,7 +197,7 @@ static void test_pwm(void)
             TRACE("Set duty cycle to %d for %d ms", duty_cycles[i], wait_time);
             pwm_set_duty_cycle(PWM_TB6612FNG_LEFT, duty_cycles[i]);
             pwm_set_duty_cycle(PWM_TB6612FNG_RIGHT, duty_cycles[i]);
-            BUSY_WAIT_ms(3000);
+            BUSY_WAIT_ms(wait_time);
         }
     }
 }
@@ -309,6 +310,21 @@ static void test_adc(void)
         for (uint8_t i = 0; i < ADC_CHANNEL_COUNT; i++) {
             TRACE("ADC ch %u: %u", i, values[i]);
         }
+        BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_qre1113(void)
+{
+    test_setup();
+    trace_init();
+    qre1113_init();
+    struct qre1113_voltages voltages = { 0, 0, 0, 0 };
+    while (1) {
+        qre1113_get_voltages(&voltages);
+        TRACE("Voltages fl %u fr %u bl %u br %u", voltages.front_left, voltages.front_right,
+                                                  voltages.back_left, voltages.back_right);
         BUSY_WAIT_ms(1000);
     }
 }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -8,6 +8,7 @@
 #include "drivers/adc.h"
 #include "drivers/qre1113.h"
 #include "app/drive.h"
+#include "app/line.h"
 #include "common/assert_handler.h"
 #include "common/defines.h"
 #include <msp430.h>
@@ -325,6 +326,18 @@ static void test_qre1113(void)
         qre1113_get_voltages(&voltages);
         TRACE("Voltages fl %u fr %u bl %u br %u", voltages.front_left, voltages.front_right,
                                                   voltages.back_left, voltages.back_right);
+        BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_line(void)
+{
+    test_setup();
+    trace_init();
+    line_init();
+    while (1) {
+        TRACE("Line %u", line_get());
         BUSY_WAIT_ms(1000);
     }
 }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -5,6 +5,7 @@
 #include "drivers/ir_remote.h"
 #include "drivers/pwm.h"
 #include "drivers/tb6612fng.h"
+#include "drivers/adc.h"
 #include "app/drive.h"
 #include "common/assert_handler.h"
 #include "common/defines.h"
@@ -294,6 +295,22 @@ static void test_assert_motors(void)
     BUSY_WAIT_ms(3000);
     ASSERT(0);
     while(0) { }
+}
+
+SUPPRESS_UNUSED
+static void test_adc(void)
+{
+    test_setup();
+    trace_init();
+    adc_init();
+    while (1) {
+        adc_channel_values_t values;
+        adc_get_channel_values(values);
+        for (uint8_t i = 0; i < ADC_CHANNEL_COUNT; i++) {
+            TRACE("ADC ch %u: %u", i, values[i]);
+        }
+        BUSY_WAIT_ms(1000);
+    }
 }
 
 int main()


### PR DESCRIPTION
The robot has four line sensors that gives a voltage output based on the light intensity in front of them, which makes it possible to detect the white boundary of the sumobot platform. Create an ADC driver to sample these voltages. Configure ADC10 peripheral to sample the sequence of channels contiguously. Interrupt each time the channels have been sampled, cache them, and then start the next round. Reduce CPU involvement by using DMA and a slow clock (ACLK).

video: 22